### PR TITLE
API: Use proper JSON Content-Type

### DIFF
--- a/api/json_v1.py
+++ b/api/json_v1.py
@@ -32,7 +32,7 @@ class ManufacturerList(webapp.RequestHandler):
   CACHE_KEY = memcache_keys.MANUFACTURER_CACHE_KEY
 
   def get(self):
-    self.response.headers['Content-Type'] = 'text/plain'
+    self.response.headers['Content-Type'] = 'application/json'
     self.response.headers['Cache-Control'] = 'public; max-age=300;'
 
     response = memcache.get(memcache_keys.MANUFACTURER_CACHE_KEY)


### PR DESCRIPTION
Fixes #130 

@peternewman proposed checking whether this change breaks [rdmprotocol.org](http://www.rdmprotocol.org/rdmusers/products/) first. (However, the Content-Type probably isn't used at all at the moment as it's used to be `text/plain`.)